### PR TITLE
Replaces emoji with twemoji

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="stylesheet" href="static/norefresh.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono|Source+Sans+Pro" rel="stylesheet">
+    <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
     <title>Johanneberg</title>
 </head>
 

--- a/static/index.js
+++ b/static/index.js
@@ -198,6 +198,8 @@ function updateScreen() {
     // Update in 15 seconds
     clearTimeout(updateTimer);
     updateTimer = setTimeout(getJson, 15000);
+    
+    twemoji.parse(document.getElementById("temperature"));
 }
 
 function printDisruption(data) {

--- a/static/norefresh.css
+++ b/static/norefresh.css
@@ -116,6 +116,12 @@ div {
     padding: 0;
 }
 
+img.emoji {
+    height: 64px;
+    margin-left: -15px;
+    padding: 0;
+}
+
 table {
     width: 100%;
 }


### PR DESCRIPTION
The computer running the web browser uses a bad looking and incomplete emoji font. This will replace all emoji with images from twemoji which is far from ideal, but it's better then the current situation. The next step is to use actual weather icons instead of using emoji.